### PR TITLE
refactor: improve clarity, consistency, and usability for gormrelay.Computed

### DIFF
--- a/FAQ_COMPUTED.md
+++ b/FAQ_COMPUTED.md
@@ -1,0 +1,413 @@
+# Frequently Asked Questions (FAQ)
+
+## Computed Fields
+
+### Why does relay use SplitScan for computed fields?
+
+Computed fields are database-calculated values (e.g., `(CASE WHEN status = 'premium' THEN 1 ELSE 3 END)`) that are often used for sorting but don't necessarily belong in your domain model.
+
+#### The Core Challenge
+
+**The fundamental requirement:** When using keyset pagination with computed fields in `OrderBy`, those computed values **must** be included in the cursor for pagination to work correctly.
+
+Consider this scenario:
+
+```go
+type Shop struct {
+    ID   int
+    Name string
+    // Note: No Priority field in the domain model
+}
+
+conn, _ := paginator.Paginate(&relay.PaginateRequest[*Shop]{
+    OrderBy: []relay.Order{
+        {Field: "Priority", Direction: relay.OrderDirectionAsc},  // Computed field!
+        {Field: "ID", Direction: relay.OrderDirectionAsc},
+    },
+})
+```
+
+For keyset pagination to work, the cursor must contain both `Priority` and `ID` values. However, `Priority` is a query-time computation, not a persistent attribute of `Shop`.
+
+#### Design Goals
+
+1. **Keep domain models pure**: `Shop` should only contain business data, not query-specific computed values
+2. **Enable cursor encoding**: Computed fields must be available during cursor serialization
+3. **Maintain type consistency**: Generic type should remain `relay.New[*Shop]`, not change based on query requirements
+4. **Runtime flexibility**: Different queries can compute different fields dynamically
+
+#### The Solution: SplitScan + Dynamic JSON Injection
+
+**Architecture:**
+
+```
+┌─────────────────────────────────────────────────────┐
+│ SQL Query                                           │
+│ SELECT id, name, (CASE...) AS _relay_computed_priority│
+└────────────────┬────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────┐
+│ SplitScan                                           │
+│  • Regular columns → Shop struct                    │
+│  • _relay_computed_* → computedResults map          │
+└────────────────┬────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────┐
+│ NodeWrapper[*Shop]                                  │
+│  • RelayNode() returns *Shop (type consistency ✓)  │
+│  • MarshalJSON() injects computedResults (cursor ✓)│
+└─────────────────────────────────────────────────────┘
+```
+
+**Implementation:**
+
+```go
+gormrelay.WithComputed(&Computed[*Shop]{
+    Columns: NewComputedColumns(map[string]string{
+        "Priority": "(CASE WHEN name = 'premium' THEN 1 ELSE 3 END)",
+    }),
+    Scanner: NewComputedScanner[*Shop],
+})
+```
+
+**How It Works:**
+
+**1. SQL Generation**
+
+```sql
+SELECT shops.id, shops.name,
+       (CASE WHEN name = 'premium' THEN 1 ELSE 3 END) AS _relay_computed_priority
+FROM shops
+ORDER BY _relay_computed_priority, shops.id
+```
+
+**2. SplitScan Separation**
+
+```go
+// Regular columns scanned into Shop struct
+shop := &Shop{ID: 1, Name: "premium"}
+
+// Computed columns extracted separately
+computedResults := map[string]any{"Priority": 1}
+```
+
+**3. Dynamic JSON Injection**
+
+```go
+type withComputedResult struct {
+    Object          any            // *Shop
+    ComputedResults map[string]any // {"Priority": 1}
+}
+
+func (v *withComputedResult) MarshalJSON() ([]byte, error) {
+    b, _ := cursor.JSONMarshal(v.Object)  // {"ID": 1, "Name": "premium"}
+
+    // Inject computed fields
+    for field, value := range v.ComputedResults {
+        b, _ = sjson.SetBytes(b, field, value)
+    }
+    // Result: {"ID": 1, "Name": "premium", "Priority": 1}
+    return b, nil
+}
+```
+
+**4. Cursor Encoding**
+
+```go
+// Create a computed node (this wraps shop with computed results)
+node := gormrelay.NewComputedNode(shop, computedResults)
+
+// Internally, this creates:
+// &cursor.NodeWrapper[*Shop]{
+//     Object: WithComputedResult(shop, computedResults),
+//     Unwrap: func() *Shop { return shop },
+// }
+
+// node.RelayNode() → returns *Shop (type: *Shop ✓)
+// node.MarshalJSON() → includes Priority (cursor: {"ID": 1, "Priority": 1} ✓)
+```
+
+#### Why This Design is Necessary
+
+**The Causal Chain:**
+
+```
+Business Requirement
+    ↓
+Order by computed field
+    ↓
+Keyset pagination requirement
+    ↓
+Cursor must contain computed field values
+    ↓
+Design Constraint
+    ↓
+Computed fields needed for cursor, not for domain model
+    ↓
+Solution
+    ↓
+Extract computed values separately
+    ↓
+Inject only during JSON serialization
+    ↓
+SplitScan is the mechanism to extract → Dynamic injection is the mechanism to provide
+```
+
+**Benefits:**
+
+- ✅ **Type consistency**: Always `relay.New[*Shop]`, never changes based on query
+- ✅ **Clean domain model**: `Shop` contains only business data
+- ✅ **Cursor encoding works**: Computed fields dynamically injected into JSON
+- ✅ **Runtime flexibility**: Can change computed columns based on permissions/context
+- ✅ **Logical cohesion**: All computed field logic centralized in `Computed` config
+
+### Why do computed columns need the `_relay_computed_` prefix?
+
+The unique prefix serves multiple critical purposes:
+
+#### 1. Marking Columns for SplitScan Interception
+
+The prefix acts as a marker to distinguish which columns should be intercepted by SplitScan:
+
+```go
+// gormrelay/scan.go
+for i, columnType := range w.columnTypes {
+    colName := columnType.Name()
+    if factory, exists := w.splitter[colName]; exists {
+        // This column is intercepted and routed to splitResults
+    } else {
+        // Regular column, scanned into destination struct
+    }
+}
+```
+
+**Example:**
+
+```sql
+SELECT id, name,
+       priority,                           -- Regular column → scanned into struct
+       (CASE...) as _relay_computed_score  -- Marked column → intercepted by SplitScan
+FROM shops
+```
+
+Without the prefix, SplitScan wouldn't know which columns to intercept.
+
+#### 2. Avoiding Column Name Conflicts
+
+**Problem: Ambiguous Column Names**
+
+Go's `sql.ColumnType` only provides column names, not positions:
+
+```go
+type ColumnType struct {
+    name string  // Only the name, no position index
+}
+```
+
+If a computed column has the same name as a table column:
+
+```sql
+-- Without unique prefix
+SELECT id, name, priority, (CASE...) as priority FROM shops
+--                  ↑                            ↑
+--            Table column              Computed column
+```
+
+Both columns would have `columnType.Name() == "priority"`, making it impossible to distinguish which should be intercepted.
+
+#### 3. GORM Column Mapping Isolation
+
+GORM maps SQL columns to struct fields based on names and tags:
+
+```go
+type Shop struct {
+    ID       int    `gorm:"column:id"`
+    Name     string `gorm:"column:name"`
+    Priority int    `gorm:"column:priority"`
+}
+```
+
+If a computed column is named `priority`:
+
+- GORM tries to map it to `Shop.Priority`
+- But SplitScan also wants to intercept it
+- Conflict occurs, behavior becomes unpredictable
+
+With `_relay_computed_priority`:
+
+- GORM sees no matching struct field → ignores it
+- SplitScan recognizes the prefix → intercepts it
+- Clean separation ✓
+
+#### 4. Database SQL Standard Compliance
+
+Most databases don't allow duplicate column names:
+
+```sql
+-- PostgreSQL error
+SELECT id, priority, priority as priority FROM shops;
+-- Error: column "priority" specified more than once
+```
+
+The unique prefix ensures SQL compliance across all databases.
+
+**Summary:**
+
+The `_relay_computed_` prefix creates a clear separation where:
+
+- Computed columns are uniquely identifiable
+- SplitScan can intercept them without ambiguity
+- GORM won't interfere with them
+- SQL remains valid and unambiguous
+
+### Can I add non-computed columns to my query?
+
+Yes! You can use `AppendSelect` to add regular columns alongside computed fields:
+
+```go
+type ShopWithExtra struct {
+    *Shop
+    ExtraInfo string `gorm:"column:extra_info"`
+}
+
+gormrelay.NewKeysetAdapter[*Shop](
+    db.Scopes(
+        AppendSelect(clause.Column{
+            Name:  "'additional data'",
+            Alias: "extra_info",
+            Raw:   true,
+        }),
+    ),
+    gormrelay.WithComputed(&Computed[*Shop]{
+        Columns: NewComputedColumns(map[string]string{
+            "Priority": "(CASE...)",
+        }),
+        Scanner: func(_ *gorm.DB) (*ComputedScanner[*Shop], error) {
+            nodes := []*ShopWithExtra{}
+            return &ComputedScanner[*Shop]{
+                Destination: &nodes,
+                Transform: func(computedResults []map[string]any) []cursor.Node[*Shop] {
+                    return lo.Map(nodes, func(s *ShopWithExtra, i int) cursor.Node[*Shop] {
+                        // ExtraInfo is populated by GORM directly
+                        // Priority is in computedResults
+                        return NewComputedNode(s.Shop, computedResults[i])
+                    })
+                },
+            }, nil
+        },
+    }),
+)
+```
+
+**How this works:**
+
+```sql
+SELECT shops.*,
+       'additional data' as extra_info,           -- Regular column → GORM scans to ExtraInfo
+       (CASE...) as _relay_computed_priority      -- Computed field → SplitScan intercepts
+FROM shops
+```
+
+- `extra_info` (no prefix) → GORM scans into `ShopWithExtra.ExtraInfo`
+- `_relay_computed_priority` (with prefix) → SplitScan intercepts into `computedResults`
+
+### Can I use computed fields without ordering by them?
+
+**Yes, you can define and query computed fields without using them in `OrderBy`.** However, they will be filtered out from the cursor encoding and won't appear in the final response by default.
+
+**Why are they filtered out?** The `EncodeKeysetCursor` function only includes fields specified in `OrderBy`:
+
+```go
+// cursor/keyset.go
+keysMap := lo.SliceToMap(keys, func(key string) (string, bool) {
+    return key, true
+})
+for k := range m {
+    if _, ok := keysMap[k]; !ok {
+        delete(m, k)  // Remove fields not in OrderBy
+    }
+}
+```
+
+Even though the computed field is queried and extracted into `computedResults`, it gets filtered out during cursor encoding if it's not in the `OrderBy` list.
+
+**How to include them in the response?** If you need computed fields for display purposes (not ordering), extract them from `computedResults` in your `ComputedScanner.Transform` and assign them to your model:
+
+```go
+type Product struct {
+    ID              int     `json:"id"`
+    Name            string  `json:"name"`
+    Price           float64 `json:"price"`
+    DiscountedPrice float64 `gorm:"-" json:"discountedPrice"`  // Will be populated from computedResults
+}
+
+gormrelay.WithComputed(&Computed[*Product]{
+    Columns: NewComputedColumns(map[string]string{
+        "DiscountedPrice": "(price * (1 - discount_rate))",
+        "Priority":        "(CASE...)",  // Used for ordering
+    }),
+    Scanner: func(_ *gorm.DB) (*ComputedScanner[*Product], error) {
+        nodes := []*Product{}
+        return &ComputedScanner[*Product]{
+            Destination: &nodes,
+            Transform: func(computedResults []map[string]any) []cursor.Node[*Product] {
+                return lo.Map(nodes, func(p *Product, i int) cursor.Node[*Product] {
+                    // Extract DiscountedPrice from computedResults and assign to Product
+                    if discounted, ok := computedResults[i]["DiscountedPrice"].(float64); ok {
+                        p.DiscountedPrice = discounted
+                    }
+
+                    return NewComputedNode(p, computedResults[i])
+                })
+            },
+        }, nil
+    },
+})
+
+OrderBy: []relay.Order{
+    {Field: "Priority", Direction: relay.OrderDirectionAsc},
+    {Field: "ID", Direction: relay.OrderDirectionAsc},
+}
+```
+
+**Result:**
+
+- `Priority` appears in cursor (via `WithComputedResult` and is in OrderBy)
+- `DiscountedPrice` appears in response JSON (via direct assignment to `p.DiscountedPrice`, filtered out from cursor)
+
+**Alternative approach:** Use `AppendSelect` with regular column aliases (without `_relay_computed_` prefix) so GORM scans them directly into your struct fields, bypassing SplitScan entirely.
+
+### How do I debug computed field issues?
+
+1. **Check SQL generation**: Enable GORM's logger to see the actual SQL
+
+   ```go
+   db.Session(&gorm.Session{Logger: logger.Default.LogMode(logger.Info)})
+   ```
+
+2. **Verify column aliases**: Ensure computed columns use `_relay_computed_` prefix in the SQL output
+
+3. **Test cursor encoding**: Check if `OrderBy` fields exist in the serialized node
+
+   ```go
+   cursor, err := cursor.EncodeKeysetCursor(node, []string{"Priority"})
+   // Error: "required key Priority not found" → computed field not injected
+   ```
+
+4. **Validate Transform function**: Ensure `computedResults` are properly applied
+   ```go
+   Transform: func(computedResults []map[string]any) []cursor.Node[*Shop] {
+       // Add debug logging
+       fmt.Printf("computedResults: %+v\n", computedResults)
+       // ...
+   }
+   ```
+
+### What are the limitations of computed fields?
+
+1. **Database-specific**: SQL expressions must be compatible with your database
+2. **No ORM validation**: Computed field expressions are passed directly to SQL
+3. **Type safety**: Type conversion between SQL and Go must be handled manually
+4. **Performance**: Complex computed expressions may impact query performance

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ p := relay.New(
             Columns: gormrelay.ComputedColumns(map[string]string{
                 "Priority": "CASE WHEN status = 'premium' THEN 1 WHEN status = 'vip' THEN 2 ELSE 3 END",
             }),
-            SetupScanner: gormrelay.NewScanner[*User],
+            Scanner: gormrelay.NewScanner[*User],
         }),
     ),
     relay.EnsureLimits[*User](10, 100),
@@ -141,9 +141,9 @@ Standard scanner function that handles result scanning and wrapping. This is the
 gormrelay.NewScanner[*User]
 ```
 
-**Custom SetupScanner**
+**Custom Scanner**
 
-For custom types or complex scenarios, implement your own SetupScanner function:
+For custom types or complex scenarios, implement your own Scanner function:
 
 ```go
 type Shop struct {
@@ -156,7 +156,7 @@ gormrelay.WithComputed(&gormrelay.Computed[*Shop]{
     Columns: gormrelay.ComputedColumns(map[string]string{
         "Priority": "CASE WHEN name = 'premium' THEN 1 ELSE 2 END",
     }),
-    SetupScanner: func(db *gorm.DB) (*gormrelay.Scanner[*Shop], error) {
+    Scanner: func(db *gorm.DB) (*gormrelay.Scanner[*Shop], error) {
         shops := []*Shop{}
         return &gormrelay.Scanner[*Shop]{
             Destination: &shops,
@@ -183,7 +183,7 @@ p := relay.New(
                 "Score": "(points * 10 + bonus)",
                 "Rank":  "CASE WHEN score > 100 THEN 'A' WHEN score > 50 THEN 'B' ELSE 'C' END",
             }),
-            SetupScanner: gormrelay.NewScanner[*User],
+            Scanner: gormrelay.NewScanner[*User],
         }),
     ),
     relay.EnsureLimits[*User](10, 100),
@@ -305,7 +305,7 @@ db.Scopes(
 
 ### Relationship Filtering
 
-The filter supports filtering by `BelongsTo` relationships with multi-level nesting:
+The filter supports filtering by `BelongsTo/HasOne` relationships with multi-level nesting:
 
 ```go
 type CountryFilter struct {
@@ -395,11 +395,16 @@ conn, err := p.Paginate(context.Background(), &relay.PaginateRequest[*User]{
 
 ### Filter Options
 
-**Disable BelongsTo Filtering:**
+**Disable Relationship Filtering:**
 
 ```go
 db.Scopes(
-    gormfilter.Scope(userFilter, gormfilter.WithDisableBelongsTo()),
+    gormfilter.Scope(
+        userFilter,
+        gormfilter.WithDisableBelongsTo(),
+        gormfilter.WithDisableHasOne(),
+        // gormfilter.WithDisableRelationships(), // disable all relationships
+    ),
 ).Find(&users)
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ p := relay.New(
             Columns: gormrelay.ComputedColumns(map[string]string{
                 "Priority": "CASE WHEN status = 'premium' THEN 1 WHEN status = 'vip' THEN 2 ELSE 3 END",
             }),
-            Scanner: gormrelay.NewScanner[*User],
+            Scanner: gormrelay.NewComputedScanner[*User],
         }),
     ),
     relay.EnsureLimits[*User](10, 100),
@@ -133,12 +133,12 @@ gormrelay.ComputedColumns(map[string]string{
 })
 ```
 
-**NewScanner**
+**NewComputedScanner**
 
 Standard scanner function that handles result scanning and wrapping. This is the recommended implementation for most use cases:
 
 ```go
-gormrelay.NewScanner[*User]
+gormrelay.NewComputedScanner[*User]
 ```
 
 **Custom Scanner**
@@ -156,7 +156,7 @@ gormrelay.WithComputed(&gormrelay.Computed[*Shop]{
     Columns: gormrelay.ComputedColumns(map[string]string{
         "Priority": "CASE WHEN name = 'premium' THEN 1 ELSE 2 END",
     }),
-    Scanner: func(db *gorm.DB) (*gormrelay.Scanner[*Shop], error) {
+    Scanner: func(db *gorm.DB) (*gormrelay.ComputedScanner[*Shop], error) {
         shops := []*Shop{}
         return &gormrelay.Scanner[*Shop]{
             Destination: &shops,
@@ -183,7 +183,7 @@ p := relay.New(
                 "Score": "(points * 10 + bonus)",
                 "Rank":  "CASE WHEN score > 100 THEN 'A' WHEN score > 50 THEN 'B' ELSE 'C' END",
             }),
-            Scanner: gormrelay.NewScanner[*User],
+            Scanner: gormrelay.NewComputedScanner[*User],
         }),
     ),
     relay.EnsureLimits[*User](10, 100),

--- a/cursor/keyset.go
+++ b/cursor/keyset.go
@@ -87,11 +87,18 @@ var jsoniterForKeyset = jsoniter.Config{
 }.Froze()
 
 func JSONMarshal(v any) ([]byte, error) {
-	return jsoniterForKeyset.Marshal(v)
+	b, err := jsoniterForKeyset.Marshal(v)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal to JSON")
+	}
+	return b, nil
 }
 
 func JSONUnmarshal(data []byte, v any) error {
-	return jsoniterForKeyset.Unmarshal(data, v)
+	if err := jsoniterForKeyset.Unmarshal(data, v); err != nil {
+		return errors.Wrap(err, "failed to unmarshal from JSON")
+	}
+	return nil
 }
 
 func EncodeKeysetCursor(node any, keys []string) (string, error) {

--- a/gormrelay/computed.go
+++ b/gormrelay/computed.go
@@ -29,8 +29,8 @@ type Computed[T any] struct {
 	// Maps field names to SQL expressions
 	Columns map[string]clause.Column
 
-	// SetupScanner prepares a scanner for database operations with computed fields
-	SetupScanner func(db *gorm.DB) (*Scanner[T], error)
+	// Scanner prepares a scanner for database operations with computed fields
+	Scanner func(db *gorm.DB) (*Scanner[T], error)
 }
 
 // Validate ensures the Computed configuration is valid.
@@ -45,8 +45,8 @@ func (c *Computed[T]) Validate() error {
 		}
 	}
 
-	if c.SetupScanner == nil {
-		return errors.New("SetupScanner function must not be nil")
+	if c.Scanner == nil {
+		return errors.New("Scanner function must not be nil")
 	}
 
 	aliasMap := make(map[string][]string)

--- a/gormrelay/computed_test.go
+++ b/gormrelay/computed_test.go
@@ -75,12 +75,12 @@ func TestWithComputedResult(t *testing.T) {
 // TestComputedValidate verifies the validation logic of the Computed struct.
 // It tests various invalid configurations to ensure they are properly rejected:
 // - Empty Columns map
-// - Nil SetupScanner function
+// - Nil Scanner function
 // - Columns with pre-defined Alias (which should be set during query execution)
 // - Duplicate column aliases that would cause SQL errors
 func TestComputedValidate(t *testing.T) {
-	// Mock SetupScanner function for testing
-	mockSetupScanner := func(db *gorm.DB) (*gormrelay.Scanner[*struct{}], error) {
+	// Mock Scanner function for testing
+	mockScanner := func(db *gorm.DB) (*gormrelay.Scanner[*struct{}], error) {
 		return nil, nil
 	}
 
@@ -96,29 +96,29 @@ func TestComputedValidate(t *testing.T) {
 				Columns: map[string]clause.Column{
 					"TotalCount": {Name: "(COUNT(*))", Raw: true},
 				},
-				SetupScanner: mockSetupScanner,
+				Scanner: mockScanner,
 			},
 			expectError: false,
 		},
 		{
 			name: "empty columns",
 			computed: &gormrelay.Computed[*struct{}]{
-				Columns:      map[string]clause.Column{},
-				SetupScanner: mockSetupScanner,
+				Columns: map[string]clause.Column{},
+				Scanner: mockScanner,
 			},
 			expectError: true,
 			errorSubstr: "Columns must not be empty",
 		},
 		{
-			name: "nil SetupScanner",
+			name: "nil Scanner",
 			computed: &gormrelay.Computed[*struct{}]{
 				Columns: map[string]clause.Column{
 					"TotalCount": {Name: "(COUNT(*))", Raw: true},
 				},
-				SetupScanner: nil,
+				Scanner: nil,
 			},
 			expectError: true,
-			errorSubstr: "SetupScanner function must not be nil",
+			errorSubstr: "Scanner function must not be nil",
 		},
 		{
 			name: "column with non-empty alias",
@@ -126,7 +126,7 @@ func TestComputedValidate(t *testing.T) {
 				Columns: map[string]clause.Column{
 					"TotalCount": {Name: "(COUNT(*))", Raw: true, Alias: "already_set"},
 				},
-				SetupScanner: mockSetupScanner,
+				Scanner: mockScanner,
 			},
 			expectError: true,
 			errorSubstr: "should have empty Alias",
@@ -138,7 +138,7 @@ func TestComputedValidate(t *testing.T) {
 					"UserScore":  {Name: "(AVG(score))", Raw: true},
 					"user_score": {Name: "(SUM(score)/COUNT(*))", Raw: true},
 				},
-				SetupScanner: mockSetupScanner,
+				Scanner: mockScanner,
 			},
 			expectError: true,
 			errorSubstr: "duplicate computed field aliases",

--- a/gormrelay/computed_test.go
+++ b/gormrelay/computed_test.go
@@ -80,7 +80,7 @@ func TestWithComputedResult(t *testing.T) {
 // - Duplicate column aliases that would cause SQL errors
 func TestComputedValidate(t *testing.T) {
 	// Mock Scanner function for testing
-	mockScanner := func(db *gorm.DB) (*gormrelay.Scanner[*struct{}], error) {
+	mockScanner := func(db *gorm.DB) (*gormrelay.ComputedScanner[*struct{}], error) {
 		return nil, nil
 	}
 
@@ -159,9 +159,9 @@ func TestComputedValidate(t *testing.T) {
 	}
 }
 
-// TestNewScanner verifies the NewScanner function correctly creates a scanner
+// TestNewComputedScanner verifies the NewComputedScanner function correctly creates a scanner
 // that combines entities with their computed results.
-func TestNewScanner(t *testing.T) {
+func TestNewComputedScanner(t *testing.T) {
 	type User struct {
 		ID   int    `json:"id"`
 		Name string `json:"name"`
@@ -182,7 +182,7 @@ func TestNewScanner(t *testing.T) {
 	db := (&gorm.DB{Statement: &gorm.Statement{}}).Model(&User{})
 
 	// Test 1: Model type matches generic type
-	scanner1, err := gormrelay.NewScanner[*User](db)
+	scanner1, err := gormrelay.NewComputedScanner[*User](db)
 	require.NoError(t, err)
 
 	// Check destination type when model matches generic type
@@ -226,7 +226,7 @@ func TestNewScanner(t *testing.T) {
 	assert.Equal(t, "Bob", user2.Name)
 
 	// Test 2: Model type does NOT match generic type
-	scanner2, err := gormrelay.NewScanner[any](db)
+	scanner2, err := gormrelay.NewComputedScanner[any](db)
 	require.NoError(t, err)
 
 	// Populate result slice with compatible nodes

--- a/gormrelay/keyset.go
+++ b/gormrelay/keyset.go
@@ -208,7 +208,7 @@ func (a *KeysetFinder[T]) Find(ctx context.Context, after, before *map[string]an
 			return nil, err
 		}
 
-		scanner, err := a.opts.Computed.SetupScanner(db)
+		scanner, err := a.opts.Computed.Scanner(db)
 		if err != nil {
 			return nil, err
 		}

--- a/gormrelay/keyset.go
+++ b/gormrelay/keyset.go
@@ -213,10 +213,10 @@ func (a *KeysetFinder[T]) Find(ctx context.Context, after, before *map[string]an
 			return nil, err
 		}
 
-		computedResults, err := splitComputedScan(
-			a.opts.Computed.Columns,
+		computedResults, err := computedSplitScan(
 			db.Scopes(scopeKeyset(a.opts.Computed.Columns, after, before, orderBy, limit, fromEnd)),
 			scanner.Destination,
+			a.opts.Computed.Columns,
 		)
 		if err != nil {
 			return nil, err

--- a/gormrelay/offset.go
+++ b/gormrelay/offset.go
@@ -96,7 +96,7 @@ func (a *OffsetFinder[T]) Find(ctx context.Context, orderBy []relay.Order, skip,
 	}
 
 	if len(computedColumns) > 0 {
-		scanner, err := a.opts.Computed.SetupScanner(db)
+		scanner, err := a.opts.Computed.Scanner(db)
 		if err != nil {
 			return nil, err
 		}

--- a/gormrelay/offset.go
+++ b/gormrelay/offset.go
@@ -101,10 +101,10 @@ func (a *OffsetFinder[T]) Find(ctx context.Context, orderBy []relay.Order, skip,
 			return nil, err
 		}
 
-		computedResults, err := splitComputedScan(
-			computedColumns,
+		computedResults, err := computedSplitScan(
 			db.Scopes(AppendSelect(maps.Values(computedColumns)...)),
 			scanner.Destination,
+			computedColumns,
 		)
 		if err != nil {
 			return nil, err

--- a/gormrelay/relay_test.go
+++ b/gormrelay/relay_test.go
@@ -773,7 +773,7 @@ func TestWithComputed(t *testing.T) {
 					Columns: ComputedColumns(map[string]string{
 						"GlobalPriority": "(CASE WHEN users.name = 'molon' THEN 1 WHEN users.name = 'sam' THEN 2 ELSE 3 END)",
 					}),
-					SetupScanner: NewScanner[*User],
+					Scanner: NewScanner[*User],
 				}),
 			),
 			relay.EnsureLimits[*User](10, 50),
@@ -922,7 +922,7 @@ func TestWithComputedShop(t *testing.T) {
 						// Define computed Priority column based on shop name
 						"Priority": "(CASE WHEN shops.name = 'premium' THEN 1 WHEN shops.name = 'featured' THEN 2 ELSE 3 END)",
 					}),
-					SetupScanner: func(_ *gorm.DB) (*Scanner[*Shop], error) {
+					Scanner: func(_ *gorm.DB) (*Scanner[*Shop], error) {
 						nodes := []*Shop{}
 						return &Scanner[*Shop]{
 							Destination: &nodes,

--- a/gormrelay/relay_test.go
+++ b/gormrelay/relay_test.go
@@ -419,12 +419,12 @@ func TestCursorHook(t *testing.T) {
 	t.Run("Base64", func(t *testing.T) {
 		t.Run("keyset", func(t *testing.T) {
 			testCase(t, func(db *gorm.DB, opts ...Option[*User]) relay.ApplyCursorsFunc[*User] {
-				return cursor.Base64[*User](NewKeysetAdapter[*User](db))
+				return cursor.Base64(NewKeysetAdapter[*User](db))
 			})
 		})
 		t.Run("keyset", func(t *testing.T) {
 			testCase(t, func(db *gorm.DB, opts ...Option[*User]) relay.ApplyCursorsFunc[*User] {
-				return cursor.Base64[*User](NewOffsetAdapter[*User](db))
+				return cursor.Base64(NewOffsetAdapter[*User](db))
 			})
 		})
 	})

--- a/gormrelay/relay_test.go
+++ b/gormrelay/relay_test.go
@@ -770,7 +770,7 @@ func TestWithComputed(t *testing.T) {
 			f(
 				db,
 				WithComputed(&Computed[*User]{
-					Columns: ComputedColumns(map[string]string{
+					Columns: NewComputedColumns(map[string]string{
 						"GlobalPriority": "(CASE WHEN users.name = 'molon' THEN 1 WHEN users.name = 'sam' THEN 2 ELSE 3 END)",
 					}),
 					Scanner: NewComputedScanner[*User],
@@ -918,7 +918,7 @@ func TestWithComputedShop(t *testing.T) {
 			f(
 				db,
 				WithComputed(&Computed[*Shop]{
-					Columns: ComputedColumns(map[string]string{
+					Columns: NewComputedColumns(map[string]string{
 						// Define computed Priority column based on shop name
 						"Priority": "(CASE WHEN shops.name = 'premium' THEN 1 WHEN shops.name = 'featured' THEN 2 ELSE 3 END)",
 					}),
@@ -929,7 +929,7 @@ func TestWithComputedShop(t *testing.T) {
 							Transform: func(computedResults []map[string]any) []cursor.Node[*Shop] {
 								return lo.Map(nodes, func(s *Shop, i int) cursor.Node[*Shop] {
 									s.Priority = int(computedResults[i]["Priority"].(int32))
-									return &cursor.SelfNode[*Shop]{Node: s}
+									return NewComputedNode(s, computedResults[i])
 								})
 							},
 						}, nil

--- a/gormrelay/relay_test.go
+++ b/gormrelay/relay_test.go
@@ -773,7 +773,7 @@ func TestWithComputed(t *testing.T) {
 					Columns: ComputedColumns(map[string]string{
 						"GlobalPriority": "(CASE WHEN users.name = 'molon' THEN 1 WHEN users.name = 'sam' THEN 2 ELSE 3 END)",
 					}),
-					Scanner: NewScanner[*User],
+					Scanner: NewComputedScanner[*User],
 				}),
 			),
 			relay.EnsureLimits[*User](10, 50),
@@ -922,9 +922,9 @@ func TestWithComputedShop(t *testing.T) {
 						// Define computed Priority column based on shop name
 						"Priority": "(CASE WHEN shops.name = 'premium' THEN 1 WHEN shops.name = 'featured' THEN 2 ELSE 3 END)",
 					}),
-					Scanner: func(_ *gorm.DB) (*Scanner[*Shop], error) {
+					Scanner: func(_ *gorm.DB) (*ComputedScanner[*Shop], error) {
 						nodes := []*Shop{}
-						return &Scanner[*Shop]{
+						return &ComputedScanner[*Shop]{
 							Destination: &nodes,
 							Transform: func(computedResults []map[string]any) []cursor.Node[*Shop] {
 								return lo.Map(nodes, func(s *Shop, i int) cursor.Node[*Shop] {


### PR DESCRIPTION
This pull request refactors the computed fields API in the `gormrelay` package to improve clarity, consistency, and usability. The main changes include renaming several types and functions related to computed fields, updating documentation and examples, and enhancing error handling for JSON marshaling. These updates make the API more intuitive and better aligned with its intended usage, while also providing clearer documentation and references.

**Computed Fields API Refactor:**

* Renamed the `Scanner` type to `ComputedScanner`, `SetupScanner` to `Scanner`, and `ComputedColumns` to `NewComputedColumns` throughout the codebase and documentation for greater clarity and consistency. The standard scanner creation function is now `NewComputedScanner`, and a new helper `NewComputedNode` was added for cursor node creation. [[1]](diffhunk://#diff-dba479eac9fd14ec6856e0389ab315f1c846f7a96be0907c4f60e69b43106984L18-R31) [[2]](diffhunk://#diff-dba479eac9fd14ec6856e0389ab315f1c846f7a96be0907c4f60e69b43106984L72-R71) [[3]](diffhunk://#diff-dba479eac9fd14ec6856e0389ab315f1c846f7a96be0907c4f60e69b43106984L123-R135) [[4]](diffhunk://#diff-dba479eac9fd14ec6856e0389ab315f1c846f7a96be0907c4f60e69b43106984L137-R150) [[5]](diffhunk://#diff-dba479eac9fd14ec6856e0389ab315f1c846f7a96be0907c4f60e69b43106984L153-R184) [[6]](diffhunk://#diff-2e5a4224000d6ca4c18f4483a9a8135e28787571a0a529c8a25ca8f321e8fc39L78-R83) [[7]](diffhunk://#diff-2e5a4224000d6ca4c18f4483a9a8135e28787571a0a529c8a25ca8f321e8fc39L99-R129) [[8]](diffhunk://#diff-2e5a4224000d6ca4c18f4483a9a8135e28787571a0a529c8a25ca8f321e8fc39L141-R141) [[9]](diffhunk://#diff-2e5a4224000d6ca4c18f4483a9a8135e28787571a0a529c8a25ca8f321e8fc39L162-R164) [[10]](diffhunk://#diff-2e5a4224000d6ca4c18f4483a9a8135e28787571a0a529c8a25ca8f321e8fc39L185-R185) [[11]](diffhunk://#diff-2e5a4224000d6ca4c18f4483a9a8135e28787571a0a529c8a25ca8f321e8fc39L229-R229) [[12]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L102-R105) [[13]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L126-R167) [[14]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L182-R186)

* Updated all usages and documentation in `README.md` to reflect the new computed fields API, including function names and struct fields. Added a reference to a new computed fields FAQ for further guidance. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L102-R105) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L126-R167) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L182-R186) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L210-R214) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L445-R453)

**Relationship Filtering Improvements:**

* Enhanced relationship filtering documentation and options to explicitly support both `BelongsTo` and `HasOne` relationships. Added new disabling options for these relationships and an option to disable all relationship filtering. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L308-R310) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L398-R409)

**Error Handling Improvements:**

* Improved error handling in JSON marshaling and unmarshaling functions in `cursor/keyset.go` by wrapping errors with additional context for easier debugging.

**Internal Refactoring:**

* Updated internal function names and usages to match the new computed fields API, including changes in keyset and offset pagination logic. [[1]](diffhunk://#diff-99c769cd0408737ea466824257d682c8be4a9ff0b743af447926120b5114bbabL211-R219) [[2]](diffhunk://#diff-31ec27c535803d2709310c8859797ae6c223e6eaf791b808b3419e3744485831L99-R107) [[3]](diffhunk://#diff-ff9cc8a283bb79b5d5ffe0f2839b44a7723cb4f059c9ac8ceb1b8f9879987c06L422-R427) [[4]](diffhunk://#diff-ff9cc8a283bb79b5d5ffe0f2839b44a7723cb4f059c9ac8ceb1b8f9879987c06L773-R776)