### PR TITLE
feat(gormfilter): add validation for empty field filters

### DIFF
--- a/filter/gormfilter/filter.go
+++ b/filter/gormfilter/filter.go
@@ -414,6 +414,10 @@ func buildFilterFieldExpr(stmt *gorm.Statement, fieldName string, filter map[str
 		}
 	}
 
+	if len(exprs) == 0 {
+		return nil, errors.Errorf("field %q filter has no operators specified", fieldName)
+	}
+
 	return clause.And(exprs...), nil
 }
 

--- a/filter/gormfilter/filter_test.go
+++ b/filter/gormfilter/filter_test.go
@@ -632,6 +632,22 @@ func TestScope(t *testing.T) {
 				wantSQL:  `SELECT * FROM "users" WHERE "users"."id" NOT IN (SELECT "profiles"."user_id" FROM "profiles" WHERE "profiles"."bio" LIKE $1 AND "profiles"."deleted_at" IS NULL) AND "users"."deleted_at" IS NULL`,
 				wantVars: []any{"%manager%"},
 			},
+			{
+				name: "fold without operators should error",
+				filter: &UserFilter{
+					Name: &filter.String{
+						Fold: true,
+					},
+				},
+				wantErrMsg: `field "Name" filter has no operators specified`,
+			},
+			{
+				name: "empty field filter should error",
+				filter: &UserFilter{
+					Name: &filter.String{},
+				},
+				wantErrMsg: `field "Name" filter has no operators specified`,
+			},
 		}
 
 		for _, tt := range tests {


### PR DESCRIPTION
- Add validation to reject field filters with no operators specified
- Previously, filters like `Name: &filter.String{}` would be silently ignored
- Now returns clear error: "field %q filter has no operators specified"
- Add test cases for both fold-only and completely empty filters

<!--
Thanks for opening a pull request!
Please read through this and fill out the checks. If they're not relevant, put N/A there.
-->

## Type of change

<!--
Add one or more of the following kinds:
- bug
- feature
- documentation
- configuration
- cleanup
- deployment (for another change)
-->

## Description

<!--
What's the change? Why do we need it?
-->

## Related issues

<!--
Which Jira issue are you resolving? Put all references here.
-->

## Notes for reviewer

<!--
What else does a reviewer need to know?
-->
